### PR TITLE
Two new features for recurse_over_arrays

### DIFF
--- a/lib/recursive_open_struct.rb
+++ b/lib/recursive_open_struct.rb
@@ -30,7 +30,7 @@ class RecursiveOpenStruct < OpenStruct
           if v.is_a?(Hash)
             @sub_elements[name] ||= RecursiveOpenStruct.new(v, :recurse_over_arrays => @recurse_over_arrays)
           elsif v.is_a?(Array) and @recurse_over_arrays
-            @sub_elements[name] ||= v.map { |a| (a.is_a? Hash) ? RecursiveOpenStruct.new(a, :recurse_over_arrays => true) : a }
+            @sub_elements[name] ||= recurse_over_array v
           else
             v
           end
@@ -40,6 +40,18 @@ class RecursiveOpenStruct < OpenStruct
       end
     end
     name
+  end
+
+  def recurse_over_array array
+    array.map do |a|
+      if a.is_a? Hash
+        RecursiveOpenStruct.new(a, :recurse_over_arrays => true)
+      elsif a.is_a? Array
+        recurse_over_array a
+      else
+        a
+      end
+    end
   end
 
   def debug_inspect(io = STDOUT, indent_level = 0, recursion_limit = 12)

--- a/spec/recursive_open_struct_spec.rb
+++ b/spec/recursive_open_struct_spec.rb
@@ -143,6 +143,19 @@ describe RecursiveOpenStruct do
 
         end
 
+        context "when array is in an array" do
+          let(:haah) { { :blah => [ blah_list ] } }
+          subject { RecursiveOpenStruct.new(haah, :recurse_over_arrays => true) }
+
+          it { subject.blah.length.should == 1 }
+          it { subject.blah[0].length.should == 3 }
+          it "Retains changes across Array lookups" do
+            subject.blah[0][1].foo = "Dr Scott"
+            subject.blah[0][1].foo.should == "Dr Scott"
+          end
+
+        end
+
       end # when recursing over arrays is enabled
 
       context "when recursing over arrays is disabled" do


### PR DESCRIPTION
These are implementations and specs for two special cases that do not work correctly a the moment.

A hash inside an array inside a hash inside a hash is not parsed:

```
RecursiveOpenStruct.new({
  foo: { 
    bar: [ { blah: 1} ] 
  } 
}, recurse_over_arrays: true)
```

A hash inside an array inside an array is not parsed:

```
RecursiveOpenStruct.new({
    bar: [ [ { blah: 1} ] ]
}, recurse_over_arrays: true)
```
