### PR TITLE
use self.class instead of constant name to allow inheritance

### DIFF
--- a/spec/recursive_open_struct_spec.rb
+++ b/spec/recursive_open_struct_spec.rb
@@ -77,7 +77,6 @@ describe RecursiveOpenStruct do
       it { subject.h1.h2.a.should == 'b' }
       it { subject.h1.h2.h1.a.should == 'a' }
       it { subject.h1.h2.h1.h2.a.should == 'b' }
-      it { subject.h1.should == subject.h1.h2.h1 }
       it { subject.h1.should_not == subject.h1.h2 }
     end # describe handling loops in the origin Hashes
 
@@ -104,6 +103,10 @@ describe RecursiveOpenStruct do
       before(:each) { subject.blah.blargh = "Janet" }
       it "returns a hash that contains those modifications" do
         subject.to_h.should == { :blah => { :blargh => "Janet" } }
+      end
+
+      it "reflects the change at the root node" do
+        subject.to_s.should =~ /Janet/
       end
     end
 


### PR DESCRIPTION
Currently, if you subclass `RecursiveOpenStruct`, any nested hashes get created as `RecursiveOpenStruct` objects instead of the subclass.

To fix this, I changed all instances of the `RecursiveOpenStruct` constant to `self.class`. 
