### PR TITLE
RecursiveOpenStruct lost when object[:prop] called instead of object.prop

### DIFF
--- a/lib/recursive_open_struct.rb
+++ b/lib/recursive_open_struct.rb
@@ -21,7 +21,7 @@ class RecursiveOpenStruct < OpenStruct
     end
   end
 
-  def [] name
+  def [](name)
     send name
   end
 

--- a/lib/recursive_open_struct.rb
+++ b/lib/recursive_open_struct.rb
@@ -21,6 +21,10 @@ class RecursiveOpenStruct < OpenStruct
     end
   end
 
+  def [] name
+    send name
+  end
+
   alias_method :to_hash, :to_h
 
   def new_ostruct_member(name)

--- a/spec/recursive_open_struct_spec.rb
+++ b/spec/recursive_open_struct_spec.rb
@@ -159,16 +159,15 @@ describe RecursiveOpenStruct do
         end
 
         context "changes after map reduction" do
-          let(:elements) { { :elements => [ { :foo => {:bar => 1} }, { :foo => {:bar => 2} }, { :foo => {:bar => 3} } ] } }
+          let(:elements) { { :elements => [ { :foo => {:bar => 1} } ] } }
           subject { RecursiveOpenStruct.new(elements, :recurse_over_arrays => true) }
 
-          it { subject.elements.length.should == 3 }
           it "Retains changes with dotted syntax" do
-            subject.elements.map(&:foo).map(&:bar).inject(0, &:+).should == 1 + 2 + 3
+            subject.elements[0].should be_an_instance_of RecursiveOpenStruct
           end
 
           it "Retains changed with hash syntax" do
-            subject.elements.map { |e| e[:foo] }.map(&:bar).inject(0, &:+).should == 1 + 2 + 3
+            subject[:elements][0].should be_an_instance_of RecursiveOpenStruct
           end
         end
       end # when recursing over arrays is enabled

--- a/spec/recursive_open_struct_spec.rb
+++ b/spec/recursive_open_struct_spec.rb
@@ -158,6 +158,19 @@ describe RecursiveOpenStruct do
 
         end
 
+        context "changes after map reduction" do
+          let(:elements) { { :elements => [ { :foo => {:bar => 1} }, { :foo => {:bar => 2} }, { :foo => {:bar => 3} } ] } }
+          subject { RecursiveOpenStruct.new(elements, :recurse_over_arrays => true) }
+
+          it { subject.elements.length.should == 3 }
+          it "Retains changes with dotted syntax" do
+            subject.elements.map(&:foo).map(&:bar).inject(0, &:+).should == 1 + 2 + 3
+          end
+
+          it "Retains changed with hash syntax" do
+            subject.elements.map { |e| e[:foo] }.map(&:bar).inject(0, &:+).should == 1 + 2 + 3
+          end
+        end
       end # when recursing over arrays is enabled
 
       context "when recursing over arrays is disabled" do


### PR DESCRIPTION
Fixes #16.