### PR TITLE
Fix recursive update of parent node tables

### DIFF
--- a/lib/recursive_open_struct.rb
+++ b/lib/recursive_open_struct.rb
@@ -3,9 +3,17 @@ require 'ostruct'
 class RecursiveOpenStruct < OpenStruct
   VERSION = "0.5.0"
 
-  def initialize(h=nil, args={})
-    @recurse_over_arrays = args.fetch(:recurse_over_arrays,false)
-    super(h)
+  def initialize(hash=nil, args={})
+    @recurse_over_arrays = args.fetch(:recurse_over_arrays, false)
+
+    super(hash)
+
+    if args.fetch(:mutate_input_hash, false)
+      hash.clear
+      @table.each { |k,v| hash[k] = v }
+      @table = hash
+    end
+
     @sub_elements = {}
   end
 
@@ -30,7 +38,9 @@ class RecursiveOpenStruct < OpenStruct
         define_method(name) do
           v = @table[name]
           if v.is_a?(Hash)
-            @sub_elements[name] ||= self.class.new(v, :recurse_over_arrays => @recurse_over_arrays)
+            @sub_elements[name] ||= self.class.new(v,
+                                      :recurse_over_arrays => @recurse_over_arrays,
+                                      :mutate_input_hash => true)
           elsif v.is_a?(Array) and @recurse_over_arrays
             @sub_elements[name] ||= recurse_over_array v
           else
@@ -93,3 +103,4 @@ class RecursiveOpenStruct < OpenStruct
   end
 
 end
+

--- a/lib/recursive_open_struct.rb
+++ b/lib/recursive_open_struct.rb
@@ -8,7 +8,8 @@ class RecursiveOpenStruct < OpenStruct
 
     super(hash)
 
-    if args.fetch(:mutate_input_hash, false)
+    if args.fetch(:mutate_input_hash, false) && hash
+      puts ">> mutate = true"
       hash.clear
       @table.each { |k,v| hash[k] = v }
       @table = hash

--- a/lib/recursive_open_struct.rb
+++ b/lib/recursive_open_struct.rb
@@ -110,26 +110,20 @@ class RecursiveOpenStruct < OpenStruct
   def deep_dup(obj, visited=[])
     if obj.is_a?(Hash)
       obj.each_with_object({}) do |(key, value), h|
-        if visited.include?(value.object_id)
-          h[key] = value
-        else
-          visited << value.object_id
-          h[key] = deep_dup(value, visited)
-        end
+        h[key] = value_or_deep_dup(value, visited)
       end
     elsif obj.is_a?(Array)
       obj.each_with_object([]) do |value, arr|
-        if visited.include?(value.object_id)
-          arr << value
-        else
-          visited << value.object_id
-          arr << deep_dup(value, visited << value.object_id)
-        end
+        arr << value_or_deep_dup(value, visited)
       end
     else
       obj
     end
   end
 
+  def value_or_deep_dup(value, visited)
+    obj_id = value.object_id
+    visited.include?(obj_id) ? value : deep_dup(value, visited << obj_id)
+  end
 end
 

--- a/lib/recursive_open_struct.rb
+++ b/lib/recursive_open_struct.rb
@@ -58,7 +58,7 @@ class RecursiveOpenStruct < OpenStruct
   def recurse_over_array array
     array.map do |a|
       if a.is_a? Hash
-        self.class.new(a, :recurse_over_arrays => true)
+        self.class.new(a, :recurse_over_arrays => true, :mutate_input_hash => true)
       elsif a.is_a? Array
         recurse_over_array a
       else

--- a/spec/recursive_open_struct_spec.rb
+++ b/spec/recursive_open_struct_spec.rb
@@ -131,15 +131,26 @@ describe RecursiveOpenStruct do
         it { subject.blah[1].foo.should == '2' }
         it { subject.blah_as_a_hash.should == blah_list }
         it { subject.blah[2].should == 'baz' }
-        it "Retains changes across Array lookups" do
-          subject.blah[1].foo = "Dr Scott"
-          subject.blah[1].foo.should == "Dr Scott"
-        end
-        it "propagates the changes through to .to_h across Array lookups" do
-          subject.blah[1].foo = "Dr Scott"
-          subject.to_h.should == {
-            :blah => [ { :foo => '1' }, { :foo => "Dr Scott" }, 'baz' ]
-          }
+
+        context "when an inner value changes" do
+          let(:updated_blah_list) { [ { :foo => '1' }, { :foo => 'Dr Scott' }, 'baz' ] }
+          let(:updated_h) { { :blah => updated_blah_list } }
+
+          before(:each) { subject.blah[1].foo = "Dr Scott" }
+
+          it "Retains changes across Array lookups" do
+            subject.blah[1].foo.should == "Dr Scott"
+          end
+          it "propagates the changes through to .to_h across Array lookups" do
+            subject.to_h.should == {
+              :blah => [ { :foo => '1' }, { :foo => "Dr Scott" }, 'baz' ]
+            }
+          end
+          it "changes the internal table" do
+            puts subject.to_s
+            updated_ros = RecursiveOpenStruct.new(updated_h)
+            subject.to_s.should == updated_ros.to_s
+          end
         end
 
         context "when array is nested deeper" do

--- a/spec/recursive_open_struct_spec.rb
+++ b/spec/recursive_open_struct_spec.rb
@@ -96,16 +96,21 @@ describe RecursiveOpenStruct do
 
     context "after a sub-element has been modified" do
       let(:hash) do
-        {
-          :blah => {
-            :blargh => 'Brad'
-          }
-        }
+        { :blah => { :blargh => "Brad" } }
       end
+      let(:updated_hash) do
+        { :blah => { :blargh => "Janet" } }
+      end
+
       subject { RecursiveOpenStruct.new(hash) }
       before(:each) { subject.blah.blargh = "Janet" }
       it "returns a hash that contains those modifications" do
-        subject.to_h.should == { :blah => { :blargh => "Janet" } }
+        subject.to_h.should == updated_hash
+      end
+
+      it "reflects the change at the root node" do
+        table = subject.instance_variable_get(:@table)
+        table.should == updated_hash
       end
     end
 

--- a/spec/recursive_open_struct_spec.rb
+++ b/spec/recursive_open_struct_spec.rb
@@ -141,15 +141,20 @@ describe RecursiveOpenStruct do
           it "Retains changes across Array lookups" do
             subject.blah[1].foo.should == "Dr Scott"
           end
+
           it "propagates the changes through to .to_h across Array lookups" do
             subject.to_h.should == {
               :blah => [ { :foo => '1' }, { :foo => "Dr Scott" }, 'baz' ]
             }
           end
+
           it "changes the internal table" do
-            puts subject.to_s
             updated_ros = RecursiveOpenStruct.new(updated_h)
             subject.to_s.should == updated_ros.to_s
+          end
+
+          it "does not mutate the input hash passed to the constructor" do
+            h[:blah][1][:foo].should == '2'
           end
         end
 

--- a/spec/recursive_open_struct_spec.rb
+++ b/spec/recursive_open_struct_spec.rb
@@ -108,9 +108,9 @@ describe RecursiveOpenStruct do
         subject.to_h.should == updated_hash
       end
 
-      it "reflects the change at the root node" do
-        table = subject.instance_variable_get(:@table)
-        table.should == updated_hash
+      it "changes the internal table" do
+        updated_ros = RecursiveOpenStruct.new(updated_hash)
+        subject.to_s.should == updated_ros.to_s
       end
     end
 

--- a/spec/recursive_open_struct_spec.rb
+++ b/spec/recursive_open_struct_spec.rb
@@ -112,6 +112,10 @@ describe RecursiveOpenStruct do
         updated_ros = RecursiveOpenStruct.new(updated_hash)
         subject.to_s.should == updated_ros.to_s
       end
+
+      it "does not mutate the input hash passed to the constructor" do
+        hash[:blah][:blargh].should == 'Brad'    
+      end
     end
 
 


### PR DESCRIPTION
Fixes #9 by keeping a reference of the hash upon initialization instead of creating an empty hash. Only does this if specified in the options hash.