### PR TITLE
Simplify initialize method

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,13 @@
 source 'http://rubygems.org'
 gemspec
 
-gem 'pry'
-
 group :development do
   if RUBY_VERSION =~ /^1\.8/
     gem 'rcov'
   else
+    gem 'pry', '~> 0.10.1'
+    gem 'rspec', '~> 3.2.0'
     gem 'simplecov'
   end
 end
+

--- a/lib/recursive_open_struct.rb
+++ b/lib/recursive_open_struct.rb
@@ -7,23 +7,12 @@ require 'recursive_open_struct/deep_dup'
 class RecursiveOpenStruct < OpenStruct
   include DebugInspect
 
-  def initialize(hash=nil, args={})
+  def initialize(hash={}, args={})
     @recurse_over_arrays = args.fetch(:recurse_over_arrays, false)
-    mutate_input_hash = args.fetch(:mutate_input_hash, false)
-
     @deep_dup = DeepDup.new(recurse_over_arrays: @recurse_over_arrays)
 
-    unless mutate_input_hash
-      hash = @deep_dup.call(hash)
-    end
-
-    super(hash)
-
-    if mutate_input_hash && hash
-      hash.clear
-      @table.each { |k,v| hash[k] = v }
-      @table = hash
-    end
+    @table = args.fetch(:mutate_input_hash, false) ? hash : @deep_dup.call(hash)
+    @table && @table.each_key { |k| new_ostruct_member(k.to_sym) }
 
     @sub_elements = {}
   end

--- a/lib/recursive_open_struct.rb
+++ b/lib/recursive_open_struct.rb
@@ -11,8 +11,10 @@ class RecursiveOpenStruct < OpenStruct
     @recurse_over_arrays = args.fetch(:recurse_over_arrays, false)
     mutate_input_hash = args.fetch(:mutate_input_hash, false)
 
+    @deep_dup = DeepDup.new(recurse_over_arrays: @recurse_over_arrays)
+
     unless mutate_input_hash
-      hash = DeepDup.new(recurse_over_arrays: @recurse_over_arrays).call(hash)
+      hash = @deep_dup.call(hash)
     end
 
     super(hash)
@@ -29,13 +31,13 @@ class RecursiveOpenStruct < OpenStruct
   def initialize_copy(orig)
     super
     # deep copy the table to separate the two objects
-    @table = DeepDup.new(recurse_over_arrays: @recurse_over_arrays).call(orig.instance_variable_get(:@table))
+    @table = @deep_dup.call(orig.instance_variable_get(:@table))
     # Forget any memoized sub-elements
     @sub_elements = {}
   end
 
   def to_h
-    DeepDup.new(recurse_over_arrays: @recurse_over_arrays).call(@table)
+    @deep_dup.call(@table)
   end
 
   alias_method :to_hash, :to_h


### PR DESCRIPTION
@aetherknight's refactoring and extraction of the deep clone method allowed the simplification of the initialize method which had some obscure code (added by myself :disappointed:)