### PR TITLE
Reinstates indifferent access behaviour

### DIFF
--- a/lib/recursive_open_struct.rb
+++ b/lib/recursive_open_struct.rb
@@ -40,6 +40,10 @@ class RecursiveOpenStruct < OpenStruct
     send name
   end
 
+  def []=(name, value)
+    modifiable[new_ostruct_member(name)] = value
+  end if RUBY_VERSION =~ /^1.9/
+
   def new_ostruct_member(name)
     key_name = _get_key_from_table_ name
     unless self.respond_to?(name)
@@ -78,6 +82,27 @@ class RecursiveOpenStruct < OpenStruct
       end
     end
   end
+
+  def delete_field(name)
+    sym = _get_key_from_table_(name)
+    singleton_class.__send__(:remove_method, sym, "#{sym}=")
+    @sub_elements.delete sym
+    @table.delete sym
+  end
+
+  def eql?(other)
+    return false unless other.kind_of?(OpenStruct)
+    @table.eql?(other.table)
+  end if RUBY_VERSION =~ /^1.9/
+
+  def hash
+    @table.hash
+  end if RUBY_VERSION =~ /^1.9/
+
+  def each_pair
+    return to_enum(:each_pair) { @table.size } unless block_given?
+    @table.each_pair{|p| yield p}
+  end if RUBY_VERSION =~ /^1.9/
 
   private
 

--- a/lib/recursive_open_struct.rb
+++ b/lib/recursive_open_struct.rb
@@ -41,28 +41,29 @@ class RecursiveOpenStruct < OpenStruct
   end
 
   def new_ostruct_member(name)
+    key_name = _get_key_from_table_ name
     unless self.respond_to?(name)
       class << self; self; end.class_eval do
         define_method(name) do
-          v = @table[name]
+          v = @table[key_name]
           if v.is_a?(Hash)
-            @sub_elements[name] ||= self.class.new(v,
+            @sub_elements[key_name] ||= self.class.new(v,
                                       :recurse_over_arrays => @recurse_over_arrays,
                                       :mutate_input_hash => true)
           elsif v.is_a?(Array) and @recurse_over_arrays
-            @sub_elements[name] ||= recurse_over_array(v)
+            @sub_elements[key_name] ||= recurse_over_array(v)
           else
             v
           end
         end
         define_method("#{name}=") do |x|
-          @sub_elements.delete(name)
-          modifiable[name] = x
+          @sub_elements.delete(key_name)
+          modifiable[key_name] = x
         end
-        define_method("#{name}_as_a_hash") { @table[name] }
+        define_method("#{name}_as_a_hash") { @table[key_name] }
       end
     end
-    name
+    key_name
   end
 
   # TODO: Make me private if/when we do an API-breaking change release
@@ -77,5 +78,14 @@ class RecursiveOpenStruct < OpenStruct
       end
     end
   end
+
+  private
+
+  def _get_key_from_table_(name)
+    return name.to_s if @table.has_key?(name.to_s)
+    return name.to_sym if @table.has_key?(name.to_sym)
+    name
+  end
+
 end
 

--- a/spec/recursive_open_struct/indifferent_access_spec.rb
+++ b/spec/recursive_open_struct/indifferent_access_spec.rb
@@ -1,0 +1,150 @@
+require_relative '../spec_helper'
+require 'recursive_open_struct'
+
+describe RecursiveOpenStruct do
+  let(:value) { 'foo' }
+  let(:symbol) { :bar }
+  let(:new_value) { 'bar' }
+  let(:new_symbol) { :foo }
+
+  describe 'indifferent access' do
+    let(:hash) { {:foo => value, 'bar' => symbol} }
+    subject(:hash_ros) { RecursiveOpenStruct.new(hash) }
+    context 'setting value with method' do
+
+      before(:each) do
+        subject.foo = value
+      end
+
+      it('allows getting with method') { expect(subject.foo).to be value }
+      it('allows getting with symbol') { expect(subject[:foo]).to be value }
+      it('allows getting with string') { expect(subject['foo']).to be value }
+
+    end
+
+    context 'setting value with symbol' do
+
+      before(:each) do
+        subject[:foo] = value
+      end
+
+      it('allows getting with method') { expect(subject.foo).to be value }
+      it('allows getting with symbol') { expect(subject[:foo]).to be value }
+      it('allows getting with string') { expect(subject['foo']).to be value }
+
+    end
+
+    context 'setting value with string' do
+
+      before(:each) do
+        subject['foo'] = value
+      end
+
+      it('allows getting with method') { expect(subject.foo).to be value }
+      it('allows getting with symbol') { expect(subject[:foo]).to be value }
+      it('allows getting with string') { expect(subject['foo']).to be value }
+
+    end
+
+    context 'overwriting values' do
+
+      context 'set with method' do
+
+        before(:each) do
+          subject.foo = value
+        end
+
+        it('overrides with symbol') do
+          subject[:foo] = new_value
+          expect(subject.foo).to be new_value
+        end
+
+        it('overrides with string') do
+          subject['foo'] = new_value
+          expect(subject.foo).to be new_value
+        end
+
+      end
+
+      context 'set with symbol' do
+
+        before(:each) do
+          subject[:foo] = value
+        end
+
+        it('overrides with method') do
+          subject.foo = new_value
+          expect(subject[:foo]).to be new_value
+        end
+
+        it('overrides with string') do
+          subject['foo'] = new_value
+          expect(subject[:foo]).to be new_value
+        end
+
+      end
+
+      context 'set with string' do
+
+        before(:each) do
+          subject['foo'] = value
+        end
+
+        it('overrides with method') do
+          subject.foo = new_value
+          expect(subject['foo']).to be new_value
+        end
+
+        it('overrides with symbol') do
+          subject[:foo] = new_value
+          expect(subject['foo']).to be new_value
+        end
+
+      end
+
+      context 'set with hash' do
+
+        it('overrides with method') do
+          hash_ros.foo = new_value
+          expect(hash_ros[:foo]).to be new_value
+
+          hash_ros.bar = new_symbol
+          expect(hash_ros['bar']).to be new_symbol
+        end
+
+        it('overrides with symbol') do
+          hash_ros[:bar] = new_symbol
+          expect(hash_ros['bar']).to be new_symbol
+        end
+
+        it('overrides with string') do
+          hash_ros['foo'] = new_value
+          expect(hash_ros[:foo]).to be new_value
+        end
+
+      end
+
+      context 'keeps original keys' do
+        subject(:recursive) { RecursiveOpenStruct.new(recursive_hash, recurse_over_arrays: true) }
+        let(:recursive_hash) { {:foo => [ {'bar' => [ { 'foo' => :bar} ] } ] } }
+        let(:modified_hash) { {:foo => [ {'bar' => [ { 'foo' => :foo} ] } ] } }
+
+        it 'after initialization' do
+          expect(hash_ros.to_h).to eq hash
+        end
+
+        it 'in recursive hashes' do
+          expect(recursive.to_h).to eq recursive_hash
+        end
+
+        it 'after resetting value' do
+          recursive.foo.first[:bar].first[:foo] = :foo
+          expect(recursive.to_h).to eq modified_hash
+        end
+
+      end
+
+    end
+
+  end
+end

--- a/spec/recursive_open_struct/ostruct_2_0_0_spec.rb
+++ b/spec/recursive_open_struct/ostruct_2_0_0_spec.rb
@@ -27,7 +27,6 @@ describe RecursiveOpenStruct do
 
       it "removes the value" do
         expect(ros.foo).to be_nil
-        is_expected
         expect(ros.to_h).to_not include(:foo)
       end
 
@@ -92,6 +91,7 @@ describe RecursiveOpenStruct do
       it "calculates table hash" do
         expect(ros.hash).to be ros.instance_variable_get('@table').hash
       end
+
     end
 
     context "each_pair" do

--- a/spec/recursive_open_struct/ostruct_2_0_0_spec.rb
+++ b/spec/recursive_open_struct/ostruct_2_0_0_spec.rb
@@ -1,0 +1,105 @@
+require_relative '../spec_helper'
+require 'recursive_open_struct'
+
+describe RecursiveOpenStruct do
+
+  let(:hash) { {:foo => 'foo', 'bar' => :bar} }
+  subject(:ros) { RecursiveOpenStruct.new(hash) }
+
+  describe "OpenStruct 2.0 methods" do
+
+    context "Hash style setter" do
+
+      it "method exists" do
+        expect(ros.respond_to?('[]=')).to be_truthy
+      end
+
+      it "changes the value" do
+        ros[:foo] = :foo
+        ros.foo = :foo
+      end
+
+    end
+
+    context "delete_field" do
+
+      before(:each) { ros.delete_field :foo }
+
+      it "removes the value" do
+        expect(ros.foo).to be_nil
+        is_expected
+        expect(ros.to_h).to_not include(:foo)
+      end
+
+      it "removes the getter method" do
+        is_expected.to_not respond_to :foo
+      end
+
+      it "removes the setter method" do
+        expect(ros.respond_to? 'foo=').to be_falsey
+      end
+
+      it "works with indifferent access" do
+        expect(ros.delete_field :bar).to eq :bar
+        is_expected.to_not respond_to :bar
+        is_expected.to_not respond_to 'bar='
+        expect(ros.to_h).to be_empty
+      end
+
+    end
+
+    context "eql?" do
+      subject(:new_ros) { ros.dup }
+
+      context "with identical ROS" do
+        subject { ros }
+        it { is_expected.to be_eql ros }
+      end
+
+      context "with similar ROS" do
+        subject { RecursiveOpenStruct.new(hash) }
+        it { is_expected.to be_eql ros }
+      end
+
+      context "with same Hash" do
+        subject { RecursiveOpenStruct.new(hash, recurse_over_arrays: true) }
+        it { is_expected.to be_eql ros }
+      end
+
+      context "with duplicated ROS" do
+        subject { ros.dup }
+
+        it "fails on different value" do
+          subject.foo = 'bar'
+          is_expected.not_to be_eql ros
+        end
+
+        it "fails on missing field" do
+          subject.delete_field :bar
+          is_expected.not_to be_eql ros
+        end
+
+        it "fails on added field" do
+          subject.baz = :baz
+          is_expected.not_to be_eql ros
+        end
+
+      end
+
+    end
+
+    context "hash" do
+      it "calculates table hash" do
+        expect(ros.hash).to be ros.instance_variable_get('@table').hash
+      end
+    end
+
+    context "each_pair" do
+      it "iterates over hash keys" do
+        expect(ros.each_pair).to match hash.each_pair
+      end
+    end
+
+  end
+
+end


### PR DESCRIPTION
This fixes issue #32.

Note that indifferent access is implemented differently than Rails' version. My implementation may have a small performance hit, but it has the advantage that the hash keys are not all transformed into strings like in Rails. This prevents unnecessary diffs in roundtripping (e.g. loading from YAML file and saving back).