### PR TITLE
to_h returns a hash with symbol keys

### DIFF
--- a/lib/recursive_open_struct/deep_dup.rb
+++ b/lib/recursive_open_struct/deep_dup.rb
@@ -12,7 +12,7 @@ class RecursiveOpenStruct::DeepDup
   def deep_dup(obj, visited=[])
     if obj.is_a?(Hash)
       obj.each_with_object({}) do |(key, value), h|
-        h[key] = value_or_deep_dup(value, visited)
+        h[key.to_sym] = value_or_deep_dup(value, visited)
       end
     elsif obj.is_a?(Array) && @recurse_over_arrays
       obj.each_with_object([]) do |value, arr|

--- a/spec/recursive_open_struct/indifferent_access_spec.rb
+++ b/spec/recursive_open_struct/indifferent_access_spec.rb
@@ -124,13 +124,14 @@ describe RecursiveOpenStruct do
 
       end
 
-      context 'keeps original keys' do
+      context 'transform original keys to symbols' do
         subject(:recursive) { RecursiveOpenStruct.new(recursive_hash, recurse_over_arrays: true) }
-        let(:recursive_hash) { {:foo => [ {'bar' => [ { 'foo' => :bar} ] } ] } }
-        let(:modified_hash) { {:foo => [ {'bar' => [ { 'foo' => :foo} ] } ] } }
+        let(:recursive_hash) { {:foo => [ {:bar => [ { :foo => :bar} ] } ] } }
+        let(:modified_hash) { {:foo => [ {:bar => [ { :foo => :foo} ] } ] } }
+        let(:symbolized_hash) { Hash[hash.map{|(k,v)| [k.to_sym,v]}] }
 
         it 'after initialization' do
-          expect(hash_ros.to_h).to eq hash
+          expect(hash_ros.to_h).to eq symbolized_hash
         end
 
         it 'in recursive hashes' do

--- a/spec/recursive_open_struct/ostruct_2_0_0_spec.rb
+++ b/spec/recursive_open_struct/ostruct_2_0_0_spec.rb
@@ -95,8 +95,8 @@ describe RecursiveOpenStruct do
     end
 
     context "each_pair" do
-      it "iterates over hash keys" do
-        expect(ros.each_pair).to match hash.each_pair
+      it "iterates over hash keys, with keys as symbol" do
+        expect(ros.each_pair).to match ({:foo => 'foo', :bar => :bar}.each_pair)
       end
     end
 


### PR DESCRIPTION
Although this is a breaking change, this is how `OpenStruct` behaves and how I expected your solution to work. 

Do you have any special reason for preserving the original keys?