### PR TITLE
Implemented lazy attribute creation in pair with Ruby's post version …

### DIFF
--- a/lib/recursive_open_struct.rb
+++ b/lib/recursive_open_struct.rb
@@ -40,7 +40,7 @@ class RecursiveOpenStruct < OpenStruct
 
   # Makes sure ROS responds as expected on #respond_to? and #method requests
   def respond_to_missing?(mid, include_private = false)
-    mname = _get_key_from_table_(mid.to_s.chomp('='))
+    mname = _get_key_from_table_(mid.to_s.chomp('=').chomp('_as_a_hash'))
     @table.key?(mname) || super
   end
 


### PR DESCRIPTION
…2.2.3 OpenStruct.

Accessor methods are now only created when needed. See pull requests 1033 and 1037 on Ruby's githug for more information on the upstream change.

This fixes #38.