### PR TITLE
Mumuki feature use symbols for hash representation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ rvm:
   - 2.1.0
   - 2.2
   - jruby-19mode
+sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 ---
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0.0
-  - 2.1.0
-  - 2.2
+  - 2.1.7
+  - 2.2.3
+  - ruby-head
   - jruby-19mode
+  - jruby-9.0.0.0
+  - jruby-head
 sudo: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.6.5 / 2015-06-30
+==================
+
+* FIX: Fix ROS when initialized with nil instead of a hash.
+
 0.6.4 / 2015-05-20
 ==================
 

--- a/README.md
+++ b/README.md
@@ -5,23 +5,34 @@ RecursiveOpenStructs.
 
 It allows for hashes within hashes to be called in a chain of methods:
 
-    ros = RecursiveOpenStruct.new( { :fooa => { :foob => 'fooc' } } )
+    ros = RecursiveOpenStruct.new( { fooa: { foob: 'fooc' } } )
 
     ros.fooa.foob # => 'fooc'
 
 Also, if needed, nested hashes can still be accessed as hashes:
 
-    ros.fooa_as_a_hash # { :foob => 'fooc' }
+    ros.fooa_as_a_hash # { foob: 'fooc' }
 
 RecursiveOpenStruct can also optionally recurse across arrays, although you
 have to explicitly enable it:
 
-    h = { :somearr => [ { :name => 'a'}, { :name => 'b' } ] }
-
-    ros = RecursiveOpenStruct.new(h, :recurse_over_arrays => true )
+    h = { :somearr => [ { name: 'a'}, { name: 'b' } ] }
+    ros = RecursiveOpenStruct.new(h, recurse_over_arrays: true )
 
     ros.somarr[0].name # => 'a'
     ros.somarr[1].name # => 'b'
+
+Also, by default it will turn all hash keys into symbols internally:
+
+    h = { 'fear' => 'is', 'the' => 'mindkiller' } }
+    ros = RecursiveOpenStruct.new(h)
+    ros.to_h # => { fear: 'is', the: 'mindkiller' }
+
+You can preserve the original keys by enabling `:preserve_original_keys`:
+
+    h = { 'fear' => 'is', 'the' => 'mindkiller' } }
+    ros = RecursiveOpenStruct.new(h, preserve_original_keys: true)
+    ros.to_h # => { 'fear' => 'is', 'the' => 'mindkiller' }
 
 ## Installation
 

--- a/lib/recursive_open_struct.rb
+++ b/lib/recursive_open_struct.rb
@@ -12,7 +12,11 @@ class RecursiveOpenStruct < OpenStruct
   def initialize(hash=nil, args={})
     hash ||= {}
     @recurse_over_arrays = args.fetch(:recurse_over_arrays, false)
-    @deep_dup = DeepDup.new(recurse_over_arrays: @recurse_over_arrays)
+    @preserve_original_keys = args.fetch(:preserve_original_keys, false)
+    @deep_dup = DeepDup.new(
+      recurse_over_arrays: @recurse_over_arrays,
+      preserve_original_keys: @preserve_original_keys
+    )
 
     @table = args.fetch(:mutate_input_hash, false) ? hash : @deep_dup.call(hash)
     @table && @table.each_key { |k| new_ostruct_member(k) }
@@ -48,8 +52,9 @@ class RecursiveOpenStruct < OpenStruct
           if v.is_a?(Hash)
             @sub_elements[key_name] ||= self.class.new(
               v,
-              :recurse_over_arrays => @recurse_over_arrays,
-              :mutate_input_hash => true
+              recurse_over_arrays: @recurse_over_arrays,
+              preserve_original_keys: @preserve_original_keys,
+              mutate_input_hash: true
             )
           elsif v.is_a?(Array) and @recurse_over_arrays
             @sub_elements[key_name] ||= recurse_over_array(v)

--- a/lib/recursive_open_struct/deep_dup.rb
+++ b/lib/recursive_open_struct/deep_dup.rb
@@ -1,6 +1,7 @@
 class RecursiveOpenStruct::DeepDup
   def initialize(opts={})
     @recurse_over_arrays = opts.fetch(:recurse_over_arrays, false)
+    @preserve_original_keys = opts.fetch(:preserve_original_keys, false)
   end
 
   def call(obj)
@@ -12,7 +13,7 @@ class RecursiveOpenStruct::DeepDup
   def deep_dup(obj, visited=[])
     if obj.is_a?(Hash)
       obj.each_with_object({}) do |(key, value), h|
-        h[key.to_sym] = value_or_deep_dup(value, visited)
+        h[@preserve_original_keys ? key : key.to_sym] = value_or_deep_dup(value, visited)
       end
     elsif obj.is_a?(Array) && @recurse_over_arrays
       obj.each_with_object([]) do |value, arr|

--- a/lib/recursive_open_struct/version.rb
+++ b/lib/recursive_open_struct/version.rb
@@ -3,5 +3,5 @@
 require 'ostruct'
 
 class RecursiveOpenStruct < OpenStruct
-  VERSION = "0.6.4"
+  VERSION = "0.6.5"
 end


### PR DESCRIPTION
This is an extension of #34 :

* #34 converts all keys to be symbols.
* Added `:preserve_original_keys` option to keep old behavior
* Updated documentation to reflect this.

This is an API-breaking change, but also a bugfix. Based on the discussion in #34 I will likely make this be a minor version release instead of a major release or a patch release.