### PR TITLE
recursive_ostruct_class option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ You can preserve the original keys by enabling `:preserve_original_keys`:
     ros = RecursiveOpenStruct.new(h, preserve_original_keys: true)
     ros.to_h # => { 'fear' => 'is', 'the' => 'mindkiller' }
 
+When subclassing RecursiveOpenStruct the subclass with be used for recursion,
+so nested elements will also be of subclass. However this means that custom
+initialize methods are also being invoked for each recursion.
+You can prevent that by enabling `:recursive_ostruct_class`:
+
+    h = { one: { two: 'three' } } }
+    s = YourSubclass.new(h, recursive_ostruct_class: true)
+    s.class.name # => YourSubclass
+    s.one.class.name # => RecursiveOpenStruct
+
 ## Installation
 
 Available as a gem in rubygems, the default gem repository.
@@ -47,7 +57,7 @@ You may also install the gem manually :
     gem install recursive-open-struct
 
 ## Contributing
- 
+
 * Fork the project.
 * Make your feature addition or bug fix.
 * Add tests for your new or changed functionality. Make sure the tests you add

--- a/spec/recursive_open_struct/recursion_and_subclassing_spec.rb
+++ b/spec/recursive_open_struct/recursion_and_subclassing_spec.rb
@@ -11,4 +11,14 @@ describe RecursiveOpenStruct do
       expect(rossc.one.first.class).to eq subclass
     end
   end
+
+  describe "don't call initializer of subclass recursively" do
+    let(:subclass) { Class.new(SubclassWithInitCheck) }
+
+    subject(:rossc) { subclass.new({ :one => {:two => :three} }, recursive_ostruct_class: true) }
+
+    specify "no error raised" do
+      expect(rossc).to_not eq nil 
+    end
+  end
 end

--- a/spec/support/subclass_with_init_check.rb
+++ b/spec/support/subclass_with_init_check.rb
@@ -1,0 +1,9 @@
+require 'recursive_open_struct'
+
+class SubclassWithInitCheck < RecursiveOpenStruct
+    def initialize(*args)
+        super
+        raise 'hash key :one required' unless self.one
+    end
+end
+


### PR DESCRIPTION
Hi. In my project I subclassed RecursiveOpenStruct and added some checks to my custom initializer, e.g.:

`raise "no :id" unless self.id`

The error was thrown even when I provided a hash with an id:

`Subclass.new({id: 1, deep: { a: 15, b: 20 }})`

Problem was: my custom initializer was called recursively (for every nested level). I think that's a problem others might stumble upon, too. The behavior I expected was that my custom initializer is being called only once and nested levels are not being created recursively with Subclass.new, but with RecursiveOpenStruct.new. So I added an option that provides exactly that.

Default behavior not changed (you have to opt-in for RecursiveOpenStruct.new on nested levels).
Test case added.
Description added.

Anything missing?
