### PR TITLE
Fixes bug #46. recurse_over_arrays now preserves array

### DIFF
--- a/lib/recursive_open_struct.rb
+++ b/lib/recursive_open_struct.rb
@@ -116,15 +116,15 @@ class RecursiveOpenStruct < OpenStruct
   end
 
   def recurse_over_array(array)
-    array.map do |a|
+    array.each_with_index do |a, i|
       if a.is_a? Hash
-        self.class.new(a, :recurse_over_arrays => true, :mutate_input_hash => true)
+        array[i] = self.class.new(a, :recurse_over_arrays => true, 
+          :mutate_input_hash => true, :preserve_original_keys => @preserve_original_keys)
       elsif a.is_a? Array
-        recurse_over_array a
-      else
-        a
+        array[i] = recurse_over_array a
       end
     end
+    array
   end
 
 end

--- a/lib/recursive_open_struct/deep_dup.rb
+++ b/lib/recursive_open_struct/deep_dup.rb
@@ -17,6 +17,7 @@ class RecursiveOpenStruct::DeepDup
       end
     elsif obj.is_a?(Array) && @recurse_over_arrays
       obj.each_with_object([]) do |value, arr|
+        value = value.is_a?(RecursiveOpenStruct) ? value.to_h : value
         arr << value_or_deep_dup(value, visited)
       end
     else

--- a/spec/recursive_open_struct/recursion_spec.rb
+++ b/spec/recursive_open_struct/recursion_spec.rb
@@ -263,7 +263,6 @@ describe RecursiveOpenStruct do
           end
 
           specify "the changes show up in .to_h" do
-            pending "This is broken"
             expect(subject.to_h).to eq({ mystery: { science: [{theatre: 9000}]}})
           end
         end


### PR DESCRIPTION
I changed the way recurse_over_array works to reuse the existing array instead of returning a new array(that was happening when using map).

That way we can rely on `@table` w/o problems. The only side effect of that is that `ros.to_h` was showing `RecursiveOpenStruct` object within the arrays, this was fixed inside deep_dup
