### PR TITLE
Save info when dumped and loaded by Marshal

### DIFF
--- a/lib/recursive_open_struct.rb
+++ b/lib/recursive_open_struct.rb
@@ -41,6 +41,7 @@ class RecursiveOpenStruct < OpenStruct
 
   def marshal_load(attributes)
     hash, @options = attributes
+    @deep_dup = DeepDup.new(@options)
     @sub_elements = {}
     super(hash)
   end

--- a/lib/recursive_open_struct.rb
+++ b/lib/recursive_open_struct.rb
@@ -39,6 +39,14 @@ class RecursiveOpenStruct < OpenStruct
     @sub_elements = {}
   end
 
+  def marshal_load(attributes)
+    hash, @options, @sub_elements = attributes
+    super(hash)
+  end
+
+  def marshal_dump
+    [super, @options, @sub_elements]
+  end
 
   if OpenStruct.public_instance_methods.include?(:initialize_copy)
     def initialize_copy(orig)

--- a/lib/recursive_open_struct.rb
+++ b/lib/recursive_open_struct.rb
@@ -40,12 +40,13 @@ class RecursiveOpenStruct < OpenStruct
   end
 
   def marshal_load(attributes)
-    hash, @options, @sub_elements = attributes
+    hash, @options = attributes
+    @sub_elements = {}
     super(hash)
   end
 
   def marshal_dump
-    [super, @options, @sub_elements]
+    [super, @options]
   end
 
   if OpenStruct.public_instance_methods.include?(:initialize_copy)


### PR DESCRIPTION
Previously, ROS did not play well when being dump and loaded with Marshal because the options from ROS did not translate through the serialization. This change saves the information through marshal_dump and then reassigns the information to ROS instance when the object is loaded.

(ideally) Fix: https://github.com/aetherknight/recursive-open-struct/issues/71