### PR TITLE
Fix Ruby 3.1 #freeze

### DIFF
--- a/lib/recursive_open_struct.rb
+++ b/lib/recursive_open_struct.rb
@@ -132,6 +132,14 @@ class RecursiveOpenStruct < OpenStruct
     end
   end
 
+  def freeze
+    @table.each_key do |key|
+      new_ostruct_member!(key)
+    end
+
+    super
+  end
+
   # TODO: Rename to new_ostruct_member! once we care less about Rubies before
   # 2.4.0.
   def new_ostruct_member(name)

--- a/spec/recursive_open_struct/open_struct_behavior_spec.rb
+++ b/spec/recursive_open_struct/open_struct_behavior_spec.rb
@@ -116,7 +116,7 @@ describe RecursiveOpenStruct do
         ros.freeze
       end
 
-      it "can read existing keys", pending: 'Awaiting fix' do
+      it "can read existing keys" do
         expect(ros.asdf).to eq 'John Smith'
       end
 
@@ -126,6 +126,22 @@ describe RecursiveOpenStruct do
 
       it "cannot write existing keys" do
         expect { ros.asdf = 'new_value' }.to raise_error FrozenError
+      end
+
+      context "with recursive structure" do
+        let(:hash) { { :key => { :subkey => 42 } } }
+
+        it "can read existing sub-elements" do
+          expect(ros.key.subkey).to eq 42
+        end
+
+        it "can write new sub-elements" do
+          expect { ros.key.new_subkey = 43 }.not_to raise_error
+        end
+
+        it "can write existing sub-elements" do
+          expect { ros.key.subkey = 43 }.not_to raise_error
+        end
       end
     end
   end # describe behavior it inherits from OpenStruct

--- a/spec/recursive_open_struct/open_struct_behavior_spec.rb
+++ b/spec/recursive_open_struct/open_struct_behavior_spec.rb
@@ -108,5 +108,25 @@ describe RecursiveOpenStruct do
         it { expect(subject.methods.map(&:to_sym)).to_not include :asdf= }
       end # describe #methods
     end # describe handling of arbitrary attributes
+
+    describe "handling of freezing" do
+      let(:hash) { { :asdf => 'John Smith' } }
+
+      before do
+        ros.freeze
+      end
+
+      it "can read existing keys", pending: 'Awaiting fix' do
+        expect(ros.asdf).to eq 'John Smith'
+      end
+
+      it "cannot write new keys" do
+        expect { ros.new_key = 'new_value' }.to raise_error FrozenError
+      end
+
+      it "cannot write existing keys" do
+        expect { ros.asdf = 'new_value' }.to raise_error FrozenError
+      end
+    end
   end # describe behavior it inherits from OpenStruct
 end


### PR DESCRIPTION
Fixes #74.

I played around with the first solution I proposed there, i.e. defining all methods during the initialization by using `super`, but there are some behaviors of `RecursiveOpenStruct` that were too specific to make it work, like the `preserve_original_keys` option. The original implementation simply [converts every key to a Symbol](https://github.com/ruby/ruby/blob/master/lib/ostruct.rb#L307).

So I went with the second option: override `Object#freeze` to create all methods before freezing the object itself.

The gem could also provide a `#deep_freeze` that would freeze the object, as well as all its sub-elements, recursively.