### PR TITLE
Add ostruct dependency due to default gem removal

### DIFF
--- a/recursive-open-struct.gemspec
+++ b/recursive-open-struct.gemspec
@@ -40,5 +40,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rdoc', [">= 0"])
   s.add_development_dependency('rspec', "~> 3.2")
   s.add_development_dependency('simplecov', [">= 0"])
+
+  s.add_dependency('ostruct')
 end
 


### PR DESCRIPTION
```
/home/hartley/.cache/asdf/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/pry-0.14.2/lib/pry.rb:31: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
```

This fixing warnings when requiring ostruct (and fixes errors in future Ruby 3.5)