### PR TITLE
Reduce gem size by excluding test files

### DIFF
--- a/recursive-open-struct.gemspec
+++ b/recursive-open-struct.gemspec
@@ -27,8 +27,7 @@ Gem::Specification.new do |s|
         ros.a_as_a_hash # { :b => 'c' }
     QUOTE
 
-  s.files = `git ls-files`.split("\n")
-  s.test_files = `git ls-files spec`.split("\n")
+  s.files = `git ls-files lib`.split("\n") + ["AUTHORS.txt" , "CHANGELOG.md", "LICENSE.txt", "README.md"]
   s.require_paths = ["lib"]
   s.extra_rdoc_files = [
     "CHANGELOG.md",
@@ -45,4 +44,3 @@ Gem::Specification.new do |s|
 
   s.add_dependency('ostruct')
 end
-


### PR DESCRIPTION
This pull request updates the *.gemspec file to optimize the gem package size and structure

```bash
$ gem build -o before.tar

$ git switch reduce-gem-size

$ gem build -o after.tar

$ du -sh before.tar after.tar
 24K	before.tar
 16K	after.tar
 ```
 
| Metric | Before | After | Saved                 |
|--------|--------|-------|-----------------------|
| Size   | 24K   | 16K   | −8K (⏷ −33.3%)     |


###  whitch files was deleted?

```diff
data
-├── .github
-│   └── workflows
-│       └── ruby.yml
 ├── lib
 │   ├── recursive_open_struct
 │   │   ├── debug_inspect.rb
 │   │   ├── deep_dup.rb
 │   │   ├── dig.rb
 │   │   └── version.rb
 │   ├── recursive_open_struct.rb
 │   └── recursive-open-struct.rb
-├── spec
-│   ├── recursive_open_struct
-│   │   ├── debug_inspect_spec.rb
-│   │   ├── indifferent_access_spec.rb
-│   │   ├── open_struct_behavior_spec.rb
-│   │   ├── ostruct_2_0_0_spec.rb
-│   │   ├── ostruct_2_3_0_spec.rb
-│   │   ├── recursion_and_subclassing_spec.rb
-│   │   ├── recursion_spec.rb
-│   │   └── wrapping_spec.rb
-│   └── spec_helper.rb
-├── .document
-├── .gitignore
-├── .rspec
-├── .travis.yml
 ├── AUTHORS.txt
 ├── CHANGELOG.md
-├── CONTRIBUTING.md
-├── Gemfile
 ├── LICENSE.txt
-├── Rakefile
 ├── README.md
-└── recursive-open-struct.gemspec
```

ps: you can see on [rails repo](https://github.com/rails/rails/blob/main/actioncable/actioncable.gemspec#L20)